### PR TITLE
fix string splitting bash env var IFS - unset it

### DIFF
--- a/build_release.sh
+++ b/build_release.sh
@@ -118,7 +118,9 @@ convert_packages(){
 replace_version(){
     replacement=$1;
     grepper=$2;
+    old_ifs=$IFS;
     IFS='' ; while read line ;do echo "$line" | grep $grepper && echo "$replacement" >> meta2.yaml  || echo "$line" >> meta2.yaml  ; done < meta.yaml
+    IFS=$old_ifs;
     mv meta2.yaml meta.yaml;
 }
 build_one_pkg(){


### PR DESCRIPTION
IFS is a built in bash env var that determines how bash splits strings.  I changed IFS in the script at one point, but failed to unset it back to what it was.  Hopefully this is what we need for the bug reported by @GoFroggyRun of the python versions being mashed together - "2.7 3.4 3.5 3.6" instead of just one of those.