### PR TITLE
Revise PLATFORMS list and PYTHON_VERSIONS list

### DIFF
--- a/policybrain_builder/cli/config.py
+++ b/policybrain_builder/cli/config.py
@@ -8,7 +8,7 @@ from .repository import Repository
 from . import utils as u
 
 
-PYTHON_VERSIONS = ('2.7', '3.5', '3.6')
+PYTHON_VERSIONS = ('2.7', '3.6')
 
 
 def setup_logging(verbose=0):

--- a/policybrain_builder/cli/package.py
+++ b/policybrain_builder/cli/package.py
@@ -7,7 +7,7 @@ from . import utils as u
 
 logger = logging.getLogger(__name__)
 
-PLATFORMS = ('osx-64', 'linux-32', 'linux-64', 'win-32', 'win-64')
+PLATFORMS = ('osx-64', 'linux-64', 'win-32', 'win-64')
 
 
 def conda_build():


### PR DESCRIPTION
This pull request removes the **linux-32** platform from the PLATFORMS list, which is hard-wired and cannot be changed using a command-line option.  No linux-32 `taxcalc` packages have been downloaded over the past year; no linux-32 `ogusa` packages have been downloaded over the past 26 months; and no linux-32 `btax` packages have been downloaded over the whole history of that project.

This pull request also removes the '3.5' item in the PYTHON_VERSIONS list because for many months now we have not been supporting Python 3.5 and we have no plans of doing that.  This change will improve the usability of the `pb` tool because this change will eliminate the need to two command-line options.

This pull request does not change any logic; it just shortens two lists.