### PR TITLE
Add simple script for releasing packages

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -17,14 +17,14 @@ GitHub organization, change `GITHUB_ORGANIZATION` to the desired username or
 GitHub organization name.
 
 Global variables:
-- GITHUB_ORGANIZATION: set either GH username or organization
+- GITHUB_ORGANIZATION: Set either GH username or organization
 - DEP_CONDA_CHANNEL: A list of non-default conda channels. The target package
                      may depend on packages that are in non-default channels.
                      This is where those non-default channels should be
                      specified.
-- CONDA_USER: the username for the package upload
-- PYTHON_VERSIONS: versions of Python for which the package should be built
-- OPERATING_SYSTEMS: operating systems for which the package should be built
+- CONDA_USER: The username for the package upload
+- PYTHON_VERSIONS: Versions of Python for which the package should be built
+- OPERATING_SYSTEMS: Operating systems for which the package should be built
 """
 
 GITHUB_ORGANIZATION = 'open-source-economics'

--- a/builder.py
+++ b/builder.py
@@ -12,11 +12,6 @@ python builder.py repo-name package-name package-version
 
 e.g. python builder.py OG-USA ogusa 0.5.11
 
-WARNING: It is highly recommended that the upstream repository is cloned for
-the purposes of building and packaging instead of a user's fork of it.
-If a user's fork is used, then it may not be up-to-date with the most recent
-changes.
-
 Note: To release a package that is outside of the open-source-economics
 GitHub organization, change `GITHUB_ORGANIZATION` to the desired username or
 GitHub organization name.

--- a/builder.py
+++ b/builder.py
@@ -1,0 +1,69 @@
+import sys
+import subprocess as sp
+import os
+import re
+
+CURRENT_DIST = 'linux-64'
+DISTS = {'linux-32', 'linux-64', 'win-32', 'win-64', 'osx-64'}
+
+def run(cmd):
+    """
+    Run shell commands, make sure they return with status '0'
+    """
+    print('running', cmd)
+    proc = sp.Popen([cmd], shell=True)
+    proc.wait()
+    assert proc.poll() == 0
+
+
+def build(python_version, repo, package, vers):
+    """
+    Build package for each distribution and upload to conda
+    """
+    vspl = python_version.split('.')
+    python_string = vspl[0] + vspl[1]
+    run(f'conda build conda.recipe --token $TOKEN --output-folder artifacts --no-anaconda-upload --python {python_version}')
+    # need to swap out the 0.5.10 for vers
+    run(f'conda convert artifacts/{CURRENT_DIST}/{package}-{vers}-py{python_string}_0.tar.bz2 -p all -o artifacts/')
+
+    # check that we have the platforms we want
+    assert len(DISTS - set(os.listdir('artifacts'))) == 0
+
+    for dist in DISTS:
+        run(f'anaconda --token $TOKEN  upload --force --user ospc artifacts/{dist}/{package}-{vers}-py{python_string}_0.tar.bz2')
+
+
+def replace_version(version):
+    """
+    Replace version in `meta.yaml` file so that it doesn't need to be updated
+    for each release
+    """
+    filename = 'conda.recipe/meta.yaml'
+    pattern = r'version: .*'
+    replacement = f'version: {version}'
+    lines = []
+    with open(filename) as f:
+        for line in f.readlines():
+            lines.append(re.sub(pattern, replacement, line))
+    with open(filename, 'w') as f:
+        for line in lines:
+            f.write(line)
+
+
+if __name__ == '__main__':
+    owner, repo, package, vers = sys.argv[1:]
+    print('owner', owner)
+    print('repo name', repo)
+    print('package name', package
+    print('package version', vers)
+    run(f'git clone https://github.com/{owner}/{repo}/')
+    os.chdir(repo)
+    run(f'git checkout -b v{vers} {vers}')
+    replace_version(vers)
+    run(f'conda config --add channels ospc')
+
+    if not os.path.isdir('artifacts'):
+        os.mkdir('artifacts')
+
+    for python_version in ('2.7', '3.6'):
+        build(python_version, repo, package, vers)

--- a/builder.py
+++ b/builder.py
@@ -3,6 +3,19 @@ import subprocess as sp
 import os
 import re
 
+
+"""
+Release a package with the following commands:
+export TOKEN=yourtoken
+python builder.py gh-username repo-name package-name package-version
+
+e.g. python builder.py open-source-economics OG-USA ogusa 0.5.11
+
+Note: `CURRENT_DIST` will have to be changed to your computer's operating
+system
+"""
+
+
 CURRENT_DIST = 'linux-64'
 DISTS = {'linux-32', 'linux-64', 'win-32', 'win-64', 'osx-64'}
 

--- a/builder.py
+++ b/builder.py
@@ -37,7 +37,7 @@ def get_current_os():
                "Expected operating systems are windows, linux, or osx.")
         raise OSError(msg.format(system_))
     # see https://docs.python.org/3.6/library/platform.html#platform.architecture
-    is_64bit = sys.maxsize > 2 **32
+    is_64bit = sys.maxsize > 2 ** 32
     n_bits = '64' if is_64bit else '32'
     return conda_name + '-' + n_bits
 

--- a/builder.py
+++ b/builder.py
@@ -30,18 +30,22 @@ def get_current_os():
     """
     Get the system corresponding to OPERATING_SYSTEMS
     """
-    conda_map = {
-        'Darwin': 'osx',
-        'Linux': 'linux',
-        'Windows': 'win'
-    }
-    os_ = platform.system()
+    system_ = platform.system()
+    if system_ == 'Darwin':
+        conda_name = 'osx'
+    elif system_ == 'Linux':
+        conda_name = 'linux'
+    elif system_ == 'Windows':
+        conda_name = 'win'
+    else:
+        msg = ("The user is using an unexpected operating system: {}.\n"
+               "Expected operating systems are windows, linux, or osx.")
+        raise OSError(msg.format(system_))
     # see https://docs.python.org/3.6/library/platform.html#platform.architecture
     is_64bit = sys.maxsize > 2 **32
     n_bits = '64' if is_64bit else '32'
-    conda_os = conda_map[os_] + '-' + n_bits
-    assert conda_os in OPERATING_SYSTEMS
-    return conda_os
+    return conda_name + '-' + n_bits
+
 
 def run(cmd):
     """

--- a/builder.py
+++ b/builder.py
@@ -36,7 +36,6 @@ def build(python_version, repo, package, vers):
     vspl = python_version.split('.')
     python_string = vspl[0] + vspl[1]
     run(f'conda build conda.recipe --token $TOKEN --output-folder artifacts --no-anaconda-upload --python {python_version}')
-    # need to swap out the 0.5.10 for vers
     run(f'conda convert artifacts/{CURRENT_DIST}/{package}-{vers}-py{python_string}_0.tar.bz2 -p all -o artifacts/')
 
     # check that we have the platforms we want

--- a/builder.py
+++ b/builder.py
@@ -22,7 +22,7 @@ system
 
 
 CURRENT_DIST = 'linux-64'
-DISTS = {'linux-32', 'linux-64', 'win-32', 'win-64', 'osx-64'}
+DISTS = {'linux-64', 'win-32', 'win-64', 'osx-64'}
 
 def run(cmd):
     """

--- a/builder.py
+++ b/builder.py
@@ -11,6 +11,11 @@ python builder.py gh-username repo-name package-name package-version
 
 e.g. python builder.py open-source-economics OG-USA ogusa 0.5.11
 
+WARNING: It is highly recommended that the upstream repository is cloned for
+the purposes of building and packaging instead of a user's fork of it.
+If a user's fork is used, then it may not be up-to-date with the most recent
+changes.
+
 Note: `CURRENT_DIST` will have to be changed to your computer's operating
 system
 """

--- a/builder.py
+++ b/builder.py
@@ -29,7 +29,7 @@ def run(cmd):
     assert proc.poll() == 0
 
 
-def build(python_version, repo, package, vers):
+def build_and_upload(python_version, repo, package, vers):
     """
     Build package for each distribution and upload to conda
     """
@@ -78,4 +78,4 @@ if __name__ == '__main__':
         os.mkdir('artifacts')
 
     for python_version in ('2.7', '3.6'):
-        build(python_version, repo, package, vers)
+        build_and_upload(python_version, repo, package, vers)

--- a/builder.py
+++ b/builder.py
@@ -26,7 +26,7 @@ GITHUB_ORGANIZATION = 'open-source-economics'
 PYTHON_VERSIONS = ['2.7', '3.6']
 OPERATING_SYSTEMS = ['linux-64', 'win-32', 'win-64', 'osx-64']
 
-def get_current_dist():
+def get_current_os():
     """
     Get the system corresponding to OPERATING_SYSTEMS
     """
@@ -55,19 +55,19 @@ def run(cmd):
 
 def build_and_upload(python_version, repo, package, vers):
     """
-    Build package for each distribution and upload to conda
+    Build package for each os and upload to conda
     """
     vspl = python_version.split('.')
     python_string = vspl[0] + vspl[1]
-    current_dist = get_current_dist()
+    current_os = get_current_os()
     run(f'conda build conda.recipe --token $TOKEN --output-folder artifacts --no-anaconda-upload --python {python_version}')
-    run(f'conda convert artifacts/{current_dist}/{package}-{vers}-py{python_string}_0.tar.bz2 -p all -o artifacts/')
+    run(f'conda convert artifacts/{current_os}/{package}-{vers}-py{python_string}_0.tar.bz2 -p all -o artifacts/')
 
     # check that we have the operating systems we want
     assert len(OPERATING_SYSTEMS - set(os.listdir('artifacts'))) == 0
 
-    for dist in OPERATING_SYSTEMS:
-        run(f'anaconda --token $TOKEN  upload --force --user ospc artifacts/{dist}/{package}-{vers}-py{python_string}_0.tar.bz2')
+    for os_ in OPERATING_SYSTEMS:
+        run(f'anaconda --token $TOKEN  upload --force --user ospc artifacts/{os_}/{package}-{vers}-py{python_string}_0.tar.bz2')
 
 
 def replace_version(version):

--- a/builder.py
+++ b/builder.py
@@ -15,9 +15,20 @@ e.g. python builder.py OG-USA ogusa 0.5.11
 Note: To release a package that is outside of the open-source-economics
 GitHub organization, change `GITHUB_ORGANIZATION` to the desired username or
 GitHub organization name.
+
+Global variables:
+- GITHUB_ORGANIZATION: set either GH username or organization
+- DEP_CONDA_CHANNEL: if package depends on another package in a non-standard
+                     channel (for multiple channels use a space delimited
+                     string like 'ospc conda-forge')
+- CONDA_USER: the username for the package upload
+- PYTHON_VERSIONS: versions of Python for which the package should be built
+- OPERATING_SYSTEMS: operating systems for which the package should be built
 """
 
 GITHUB_ORGANIZATION = 'open-source-economics'
+DEP_CONDA_CHANNEL = 'ospc'
+CONDA_USER = 'ospc'
 PYTHON_VERSIONS = ['2.7', '3.6']
 OPERATING_SYSTEMS = ['linux-64', 'win-32', 'win-64', 'osx-64']
 
@@ -66,7 +77,7 @@ def build_and_upload(python_version, repo, package, vers):
     assert len(OPERATING_SYSTEMS - set(os.listdir('artifacts'))) == 0
 
     for os_ in OPERATING_SYSTEMS:
-        run(f'anaconda --token $TOKEN  upload --force --user ospc artifacts/{os_}/{package}-{vers}-py{python_string}_0.tar.bz2')
+        run(f'anaconda --token $TOKEN  upload --force --user {USER} artifacts/{os_}/{package}-{vers}-py{python_string}_0.tar.bz2')
 
 
 def replace_version(version):
@@ -95,7 +106,9 @@ if __name__ == '__main__':
     os.chdir(repo)
     run(f'git checkout -b v{vers} {vers}')
     replace_version(vers)
-    run(f'conda config --add channels ospc')
+    # add depenedent channels if specified
+    if DEP_CONDA_CHANNEL:
+        run(f'conda config --add channels {DEP_CONDA_CHANNEL}')
 
     if not os.path.isdir('artifacts'):
         os.mkdir('artifacts')

--- a/builder.py
+++ b/builder.py
@@ -77,7 +77,7 @@ def build_and_upload(python_version, repo, package, vers):
     assert len(OPERATING_SYSTEMS - set(os.listdir('artifacts'))) == 0
 
     for os_ in OPERATING_SYSTEMS:
-        run(f'anaconda --token $TOKEN  upload --force --user {USER} artifacts/{os_}/{package}-{vers}-py{python_string}_0.tar.bz2')
+        run(f'anaconda --token $TOKEN  upload --force --user {CONDA_USER} artifacts/{os_}/{package}-{vers}-py{python_string}_0.tar.bz2')
 
 
 def replace_version(version):

--- a/builder.py
+++ b/builder.py
@@ -18,16 +18,17 @@ GitHub organization name.
 
 Global variables:
 - GITHUB_ORGANIZATION: set either GH username or organization
-- DEP_CONDA_CHANNEL: if package depends on another package in a non-standard
-                     channel (for multiple channels use a space delimited
-                     string like 'ospc conda-forge')
+- DEP_CONDA_CHANNEL: A list of non-default conda channels. The target package
+                     may depend on packages that are in non-default channels.
+                     This is where those non-default channels should be
+                     specified.
 - CONDA_USER: the username for the package upload
 - PYTHON_VERSIONS: versions of Python for which the package should be built
 - OPERATING_SYSTEMS: operating systems for which the package should be built
 """
 
 GITHUB_ORGANIZATION = 'open-source-economics'
-DEP_CONDA_CHANNEL = 'ospc'
+DEP_CONDA_CHANNELS = ['ospc']
 CONDA_USER = 'ospc'
 PYTHON_VERSIONS = ['2.7', '3.6']
 OPERATING_SYSTEMS = ['linux-64', 'win-32', 'win-64', 'osx-64']
@@ -107,8 +108,8 @@ if __name__ == '__main__':
     run(f'git checkout -b v{vers} {vers}')
     replace_version(vers)
     # add depenedent channels if specified
-    if DEP_CONDA_CHANNEL:
-        run(f'conda config --add channels {DEP_CONDA_CHANNEL}')
+    for channel in DEP_CONDA_CHANNELS:
+        run(f'conda config --add channels {channel}')
 
     if not os.path.isdir('artifacts'):
         os.mkdir('artifacts')


### PR DESCRIPTION
This PR proposes a simple script that does most of the things that this repo does but in a simpler way.

Advantages:
- Can build and upload conda packages for any repo that has the required `meta.yaml`, `bld.bat`, and `bld.sh` files. The current setup works only for a couple packages and is very restrictive in how those are setup.
- Very simple--it is about 70 lines long and it is pretty straightforward to grok what is going on and make changes

Disadvantages:
- I haven't added any commandline argument parses to this beyond reading items from `sys.argv`. A basic argument parser can be added with little effort using `argparse` or something similar.
- This repo is polished and has very nice ouptut. This script dumps all output to stdout without the fancy colors.
- There may be a few other features that I am not aware of that are not here.

@martinholmer @jdebacker Does this script look like it could be useful for you? Does my analysis of the pros/cons seem sensible?

Also, I successfully released OG-USA 0.5.11 with this script.