### PR TITLE
Update README.md with link to new taxcalc usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ pb build --python 3.6
 Note that the default (that is, using no `--python` option) implies
 packages will be built for both Python 2.7 and Python 3.6.
 
-### Complete bash script that creates `taxcalc` packages
+### Complete bash shell script that creates `taxcalc` packages
 
-See the full explanation in [this comment](https://github.com/open-source-economics/policybrain-builder/issues/74#issue-268242989).
+See the full explanation in [this comment](https://github.com/open-source-economics/policybrain-builder/issues/86).
 
 ## Environment variables
 

--- a/builder.py
+++ b/builder.py
@@ -1,7 +1,8 @@
 """
-==========================================================================
-WARNING: this script is still under development is is not yet ready to use
-==========================================================================
+NOTE: this Python script was developed by Hank Doupe as an alternative
+to the pb CLI tool documented in the policybrain-builder/README.md file.
+If you have questions about or problems with this builder.py script,
+please direct your questions to Hank, @hdoupe, on GitHub.
 
 Build and upload a conda package with the following commands:
 


### PR DESCRIPTION
This pull request provides documentation for usage of the `pb` CLI tool in releasing conda `taxcalc` packages for Python 3.6 only.