### PR TITLE
Changes for version 0.3.0

### DIFF
--- a/policybrain_builder/cli/config.py
+++ b/policybrain_builder/cli/config.py
@@ -8,7 +8,7 @@ from .repository import Repository
 from . import utils as u
 
 
-PYTHON_VERSIONS = ('2.7', '3.6')
+PYTHON_VERSIONS = ('3.6',)
 
 
 def setup_logging(verbose=0):

--- a/policybrain_builder/cli/main.py
+++ b/policybrain_builder/cli/main.py
@@ -45,7 +45,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
-@click.version_option(prog_name="pb", version="0.2.0")
+@click.version_option(prog_name="pb", version="0.3.0")
 @click.pass_context
 @u.required_commands("anaconda", "conda", "git", "tar", "tsort")
 def cli(ctx):

--- a/policybrain_builder/cli/utils.py
+++ b/policybrain_builder/cli/utils.py
@@ -23,7 +23,8 @@ def required_commands(*commands):
                     # Unix-specific command lookup
                     check_output("which {}".format(command))
                 except subprocess.CalledProcessError:
-                    logger.error("Required command does not exist: %s", command)
+                    msg = "Required command does not exist: %s"
+                    logger.error(msg, command)
                     failed = True
             if failed:
                 sys.exit(1)
@@ -70,7 +71,9 @@ def call(cmd):
 def check_output(cmd):
     logger.debug(cmd)
     try:
-        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).decode("utf-8")
+        output = subprocess.check_output(cmd,
+                                         stderr=subprocess.STDOUT,
+                                         shell=True).decode("utf-8")
     except subprocess.CalledProcessError as e:
         logger.error(e)
         sys.exit(e.returncode)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', encoding='utf-8') as f:
     readme = f.read()
 
 setup(name="policybrain-builder",
-      version="0.2.0",
+      version="0.3.0",
       description="Open Source Policy Center (OSPC) package management",
       url="https://github.com/open-source-economics/policybrain-builder",
       author="Joseph Crail",


### PR DESCRIPTION
This pull request makes a couple of changes in the code to handle the new warning messages emitted from recent versions of conda-build.  Now calls to conda build often return these new lines of output:
```
read filter "zstd" is not supported
write filter "zstd" is not supported
```
Another substantive change is that now only packages for Python 3.6 can be generated (that is, no Python 2.7 packages are generated).

In addition, the code in `packages.py` has been reformatted so that `pycodestyle` generates fewer errors when run over all the `*py` files in the repository.
