### PR TITLE
Add release-packages.sh script to repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.pyc
 __pycache__
 .DS_Store
-make-taxcalc-packages*
+policybrain_builder.egg-info/
+build/
+dist/

--- a/policybrain_builder/cli/main.py
+++ b/policybrain_builder/cli/main.py
@@ -37,7 +37,7 @@ def is_authenticated_user():
 
 
 def default_token_config():
-    path = os.path.join(os.path.expanduser("~"), ".ospc_anaconda_token")
+    path = os.path.expanduser("~/.ospc_anaconda_token")
     if os.path.exists(path):
         return path
     return None
@@ -47,7 +47,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
-@click.version_option(prog_name="pb", version="0.5.0")
+@click.version_option(prog_name="pb", version="0.6.0")
 @click.pass_context
 @u.required_commands("anaconda", "conda", "git", "tar", "tsort")
 def cli(ctx):

--- a/release-packages.sh
+++ b/release-packages.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Script to build locally and upload to the Anaconda Cloud conda packages for
+# models in the USA tax collection of the Policy Simulation Library (PSL).
+# The script uses the policybrain-builder CLI, pb, to do the build/upload work.
+# The script requires two command-line arguments:
+#   NAME : name of the model packages to build and upload (e.g., btax)
+#   TAG : model release number (e.g., 0.2.2)
+# The script uses the latest version of taxcalc available in the Anaconda Cloud.
+# NOTE: for this script to work the NAME must be specified in the
+#       policybrain_builder/cli/config.py file's get_packages function
+#       and have taxcalc as a dependency, and
+#       the TAG must be a release in the NAME's repository.
+# USAGE: ./release-packages.sh NAME TAG
+
+DEBUG=false
+
+# check script arguments
+if [[ $# -ne 2 ]]; then
+    echo "USAGE: ./release-packages.sh NAME TAG"
+    exit 1
+fi
+NAME=$1
+TAG=$2
+regex="^(taxcalc|behresp|btax|ogusa)$"
+if [[ ! $NAME =~ $regex ]]; then
+    echo "ERROR: NAME=$NAME not recognized"
+    exit 1
+fi
+regex="^[0-9]+\.[0-9]+\.[0-9]+$"
+if [[ ! $TAG =~ $regex ]]; then
+    echo "ERROR: TAG=$TAG not valid"
+    exit 1
+fi
+
+# begin script execution
+echo "STARTING : `date`"
+
+echo "[$NAME] clearing-deck"
+
+# uninstall local taxcalc package
+conda list taxcalc | awk '$1~/taxcalc/{rc=1}END{exit(rc)}'
+if [[ $? -eq 1 ]]; then
+    conda uninstall taxcalc --yes 2>&1 > /dev/null
+fi
+
+# set pb release OPTIONS and possibly install taxcalc
+if [[ "$NAME" == "taxcalc" ]]; then
+    OPTIONS="--clean"
+else
+    OPTIONS="--clean --only-last taxcalc"
+    echo "[$NAME] setting-up taxcalc"
+    # install newest version of taxcalc package from the Anaconda Cloud
+    conda install -c ospc taxcalc --yes 2>&1 > /dev/null
+fi
+
+# build and upload packages for other model that depends on taxcalc
+if [[ "$DEBUG" == "true" ]]; then
+    pb release $OPTIONS $NAME=$TAG
+else    
+    pb release $OPTIONS $NAME=$TAG 2>&1 | awk -v nstr="[$NAME]" '$1==nstr'
+fi
+
+echo "[$NAME] cleaning-up"
+
+# uninstall taxcalc package used in building non-taxcalc packages
+if [[ "$NAME" != "taxcalc" ]]; then
+    conda uninstall taxcalc --yes 2>&1 > /dev/null
+fi
+
+# clean up local files created in the build+upload process
+conda build purge 2> /dev/null
+find ~/anaconda3/conda-bld -name "*tar.bz2" -exec rm -f {} \;
+rm -rf ~/tmp/policybrain-builder
+
+echo "FINISHED : `date`"
+exit 0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', encoding='utf-8') as f:
     readme = f.read()
 
 setup(name="policybrain-builder",
-      version="0.5.0",
+      version="0.6.0",
       description="Open Source Policy Center (OSPC) package management",
       url="https://github.com/open-source-economics/policybrain-builder",
       author="Joseph Crail",


### PR DESCRIPTION
The new `release-packages.sh` bash script uses version 0.6.0 of the `pb` CLI tool to build, and upload to the Anaconda Cloud, conda packages for Tax-Calculator and for other models in the USA tax collection of the Policy Simulation Library (PSL).   It works smoothly for Tax-Calculator (taxcalc) and for Behavioral-Responses (behresp), and it will be tested soon on other models in the PSL USA tax collection.  After that additional testing, the documentation for this repo will be revised to reflect the current version of `pb` and `release-packages.sh`.